### PR TITLE
204 Add due date to maintenance plan

### DIFF
--- a/apilayer/dataLake/hoard/dataLake.go
+++ b/apilayer/dataLake/hoard/dataLake.go
@@ -44,7 +44,8 @@ func IngestSvc() {
 	}
 	GenerateFakeDataWithLimit(currentUser, 2, "note", creatorID)
 	GenerateFakeDataWithLimit(currentUser, 2, "inventory", creatorID)
-
+	GenerateFakeDataWithLimit(currentUser, 2, "category", creatorID)
+	GenerateFakeDataWithLimit(currentUser, 2, "maintenance_plan", creatorID)
 }
 
 // GenerateFakeDataWithLimit ...
@@ -67,9 +68,77 @@ func GenerateFakeDataWithLimit(user string, minCount int, typeOf string, creator
 	case "inventory":
 		log.Printf("loading %d of inventory rows", rowCounts)
 		populateFakeInventories(user, rowCounts, creatorID)
+	case "category":
+		log.Printf("loading %d of category rows", rowCounts)
+		populateFakeCategories(user, rowCounts, creatorID)
+	case "maintenance_plan":
+		log.Printf("loading %d of maintenance plan rows", rowCounts)
+		populateFakeMaintenancePlans(user, rowCounts, creatorID)
 	default:
 	}
 	return nil
+}
+
+// populateFakeCategories ...
+//
+// generate fake category data to test in the application
+func populateFakeCategories(user string, limit int, creatorID string) {
+
+	for i := 1; i <= limit; i++ {
+		draftCategory := model.Category{}
+		// time is set for created / updated
+		now := time.Now()
+		daysAgo := gofakeit.Number(1, 30)
+		startDate := now.AddDate(0, 0, -daysAgo)
+
+		draftCategory.Name = gofakeit.JobTitle()
+		draftCategory.Description = gofakeit.HipsterSentence(2)
+		draftCategory.Color = gofakeit.RandString([]string{"#ffcc99", "#ff00ff", "#bb5588"})
+		draftCategory.MinItemsLimit = gofakeit.Number(1, 10)
+		draftCategory.MaxItemsLimit = gofakeit.Number(10, 100)
+		draftCategory.Status = "draft"
+		draftCategory.CreatedAt = startDate
+		draftCategory.UpdatedAt = startDate
+		draftCategory.CreatedBy = creatorID
+		draftCategory.Creator = gofakeit.FirstName()
+		draftCategory.UpdatedBy = creatorID
+		draftCategory.Updator = gofakeit.FirstName()
+		draftCategory.SharableGroups = []string{creatorID}
+
+		db.CreateCategory(user, &draftCategory)
+	}
+}
+
+// populateFakeMaintenancePlans ...
+//
+// generate fake maintenance plan data to test in the application
+func populateFakeMaintenancePlans(user string, limit int, creatorID string) {
+
+	for i := 1; i <= limit; i++ {
+		draftMaintenancePlan := model.MaintenancePlan{}
+		// time is set for created / updated
+		now := time.Now()
+		daysAgo := gofakeit.Number(1, 30)
+		startDate := now.AddDate(0, 0, -daysAgo)
+
+		draftMaintenancePlan.Name = gofakeit.JobTitle()
+		draftMaintenancePlan.Description = gofakeit.HipsterSentence(2)
+		draftMaintenancePlan.Color = gofakeit.RandString([]string{"#ffcc99", "#ff00ff", "#bb5588"})
+		draftMaintenancePlan.MinItemsLimit = gofakeit.Number(1, 10)
+		draftMaintenancePlan.MaxItemsLimit = gofakeit.Number(10, 100)
+		draftMaintenancePlan.Status = "draft"
+		draftMaintenancePlan.PlanType = gofakeit.RandString([]string{"annual", "weekly", "daily"})
+		draftMaintenancePlan.PlanDue = startDate
+		draftMaintenancePlan.CreatedAt = startDate
+		draftMaintenancePlan.UpdatedAt = startDate
+		draftMaintenancePlan.CreatedBy = creatorID
+		draftMaintenancePlan.Creator = gofakeit.FirstName()
+		draftMaintenancePlan.UpdatedBy = creatorID
+		draftMaintenancePlan.Updator = gofakeit.FirstName()
+		draftMaintenancePlan.SharableGroups = []string{creatorID}
+
+		db.CreateMaintenancePlan(user, &draftMaintenancePlan)
+	}
 }
 
 // populateFakeNotes ...

--- a/apilayer/db/Categoriesdb.go
+++ b/apilayer/db/Categoriesdb.go
@@ -200,8 +200,7 @@ func CreateCategory(user string, draftCategory *model.Category) (*model.Category
 	defer db.Close()
 
 	// retrieve selected status
-	selectedStatusIDSqlStr := `SELECT id, name, description FROM community.statuses s WHERE s.name=$2 AND $1::UUID = ANY(s.sharable_groups);`
-	selectedStatusDetails, err := retrieveStatusDetails(user, draftCategory.CreatedBy, draftCategory.Status, selectedStatusIDSqlStr)
+	selectedStatusDetails, err := RetrieveStatusDetails(user, draftCategory.CreatedBy, draftCategory.Status)
 	if err != nil {
 		log.Printf("error retrieving status details: %+v", err)
 		return nil, err
@@ -279,9 +278,7 @@ func UpdateCategory(user string, userID string, draftCategory *model.Category) (
 	}
 	defer db.Close()
 
-	// retrieve selected status
-	selectedStatusIDSqlStr := `SELECT id, name, description FROM community.statuses s WHERE s.name=$2 AND $1::UUID = ANY(s.sharable_groups);`
-	selectedStatusDetails, err := retrieveStatusDetails(user, userID, draftCategory.Status, selectedStatusIDSqlStr)
+	selectedStatusDetails, err := RetrieveStatusDetails(user, userID, draftCategory.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/apilayer/db/Profiledb.go
+++ b/apilayer/db/Profiledb.go
@@ -303,7 +303,7 @@ func getFavouriteItems(db *sql.DB, userID string, limit int) ([]model.FavouriteI
 		LEFT JOIN community.category c ON c.id = fi.category_id 
 		LEFT JOIN community.statuses s ON s.id = c.status 
 		LEFT JOIN community.maintenance_plan mp ON mp.id = fi.maintenance_plan_id
-		LEFT JOIN community.maintenance_status ms ON ms.id = mp.maintenance_status WHERE fi.created_by = $1 
+		LEFT JOIN community.statuses ms ON ms.id = mp.status WHERE fi.created_by = $1 
 	FETCH FIRST $2 rows only;`
 
 	rows, err := db.Query(sqlStr, userID, limit)

--- a/apilayer/db/Reportdb.go
+++ b/apilayer/db/Reportdb.go
@@ -40,7 +40,6 @@ func RetrieveReports(user string, userID uuid.UUID, sinceDateTime string, includ
 
 	var reports []model.Report
 	rows, err := db.Query(parsedSqlStr, userID, sinceDateTime)
-	log.Printf("sqlStr := %+v, %+s, %+v", parsedSqlStr, userID.String(), sinceDateTime)
 	if err != nil {
 		log.Printf("unable to retrieve report details. error: %+v", err)
 		return nil, err

--- a/apilayer/handler/MaintenancePlan_test.go
+++ b/apilayer/handler/MaintenancePlan_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mohit2530/communityCare/config"
@@ -198,10 +199,11 @@ func Test_CreateMaintenancePlan(t *testing.T) {
 		Name:           "Kitty litter box",
 		Description:    "Palette storage of kitty litter",
 		Color:          "#f7f7f7",
-		Status:         "Approved",
+		Status:         "completed",
 		MaxItemsLimit:  120,
 		MinItemsLimit:  1,
 		PlanType:       "annual",
+		PlanDue:        time.Now().AddDate(1, 0, 0),
 		CreatedBy:      prevUser.ID.String(),
 		UpdatedBy:      prevUser.ID.String(),
 		SharableGroups: []string{prevUser.ID.String()},
@@ -232,7 +234,7 @@ func Test_CreateMaintenancePlan(t *testing.T) {
 
 	assert.Equal(t, selectedMaintenancePlan.Name, "Kitty litter box")
 	assert.Equal(t, selectedMaintenancePlan.Description, "Palette storage of kitty litter")
-	assert.Equal(t, selectedMaintenancePlan.StatusName, "Approved")
+	assert.Equal(t, selectedMaintenancePlan.StatusName, "completed")
 	assert.Equal(t, selectedMaintenancePlan.MaxItemsLimit, 120)
 	assert.Equal(t, selectedMaintenancePlan.MinItemsLimit, 1)
 	assert.Equal(t, selectedMaintenancePlan.PlanType, "annual")
@@ -305,7 +307,7 @@ func Test_UpdateMaintenancePlan(t *testing.T) {
 
 	selectedMaintenancePlan.Name = "Updated Title"
 	selectedMaintenancePlan.Description = "Update title description"
-	selectedMaintenancePlan.Status = "Rejected" // change status so id is not passed to service
+	selectedMaintenancePlan.Status = "completed" // change status so id is not passed to service
 
 	// Marshal the draftUpdateEvent into JSON bytes
 	updateMaintenancePlanRequest, err := json.Marshal(selectedMaintenancePlan)
@@ -333,7 +335,7 @@ func Test_UpdateMaintenancePlan(t *testing.T) {
 		t.Errorf("expected error to be nil got %v", err)
 	}
 	assert.Equal(t, updatedMaintenancePlan.Name, "Updated Title")
-	assert.Equal(t, updatedMaintenancePlan.StatusName, "Rejected")
+	assert.Equal(t, updatedMaintenancePlan.StatusName, "completed")
 
 	// cleanup
 	db.RemoveMaintenancePlan(config.CTO_USER, updatedMaintenancePlan.ID)

--- a/apilayer/handler/Statuses.go
+++ b/apilayer/handler/Statuses.go
@@ -42,7 +42,7 @@ func GetStatusList(rw http.ResponseWriter, r *http.Request, user string) {
 		return
 	}
 
-	resp, err := db.FetchStatusList(user, userID, statusOptionType)
+	resp, err := db.MaintenanceStatusList(user, userID, statusOptionType)
 	if err != nil {
 		log.Printf("Unable to retrieve status list. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/model/MaintenancePlan.go
+++ b/apilayer/model/MaintenancePlan.go
@@ -17,6 +17,7 @@ type MaintenancePlan struct {
 	MinItemsLimit     int       `json:"min_items_limit"`
 	MaxItemsLimit     int       `json:"max_items_limit"`
 	PlanType          string    `json:"plan_type"`
+	PlanDue           time.Time `json:"plan_due"`
 	Location          Location  `json:"location,omitempty"`
 	CreatedBy         string    `json:"created_by"`
 	CreatedAt         time.Time `json:"created_at"`

--- a/frontend/src/features/Maintenance/Plan.jsx
+++ b/frontend/src/features/Maintenance/Plan.jsx
@@ -45,7 +45,7 @@ const Plan = () => {
       </Stack>
       <PlanList
         maintenancePlan={maintenancePlan}
-        loading={loading}
+        loading={displayModal ? false : loading} // do not refresh page if add modal is present
         setDisplayModal={setDisplayModal}
         setSelectedMaintenancePlanID={setSelectedMaintenancePlanID}
       />

--- a/frontend/src/features/Maintenance/constants.jsx
+++ b/frontend/src/features/Maintenance/constants.jsx
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 export const ITEMS_IN_MAINTENANCE_PLAN_HEADER = [
   { field: 'name', headerName: 'Name', flex: 1 },
   { field: 'description', headerName: 'Description', flex: 2 },
@@ -11,30 +13,38 @@ export const ITEM_TYPE_MAPPER = {
   daily: {
     display: 'Daily',
     value: 'daily',
+    since: dayjs().add(1, 'day').toISOString(),
   },
   weekly: {
     display: 'Weekly',
     value: 'weekly',
+    since: dayjs().add(7, 'days').toISOString(),
   },
   biweekly: {
     display: 'Bi-Weekly',
     value: 'biweekly',
+    since: dayjs().add(15, 'days').toISOString(),
   },
   monthly: {
     display: 'Monthly',
     value: 'monthly',
+    since: dayjs().add(30, 'days').toISOString(),
   },
   quaterly: {
     display: 'Quaterly',
     value: 'quaterly',
+    since: dayjs().add(3, 'months').toISOString(),
+
   },
   semiannually: {
     display: 'Semi-annually',
     value: 'semiannually',
+    since: dayjs().add(6, 'months').toISOString(),
   },
   annual: {
     display: 'Annually',
     value: 'annual',
+    since: dayjs().add(1, 'year').toISOString(),
   },
 };
 

--- a/server/migrations/0016_create_maintenance_plan_table.up.sql
+++ b/server/migrations/0016_create_maintenance_plan_table.up.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS community.maintenance_plan
     name                VARCHAR(100)                                                                                            NOT NULL,
     description         VARCHAR(500),
     color               VARCHAR(50),
-    maintenance_status  UUID                         REFERENCES maintenance_status (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    status              UUID                         REFERENCES statuses (id) ON UPDATE CASCADE ON DELETE CASCADE,
     min_items_limit     INT                                                                                                     NOT NULL DEFAULT 1, 
     max_items_limit     INT                                                                                                     NOT NULL DEFAULT 1,
     plan_type           VARCHAR(100)                                                                                            NOT NULL DEFAULT 'annual',

--- a/server/migrations/0023_update_table_maintenance_plan.up.sql
+++ b/server/migrations/0023_update_table_maintenance_plan.up.sql
@@ -1,0 +1,9 @@
+
+-- File: 0023_update_table_maintenance_plan.up.sql
+-- Description: Update maintenance plan table to support due date
+
+
+SET search_path TO community, public;
+
+ALTER TABLE community.maintenance_plan
+ADD COLUMN plan_due TIMESTAMP WITH TIME ZONE NOT NULL;

--- a/server/migrations/0024_truncate_maintenance_status_table.up.sql
+++ b/server/migrations/0024_truncate_maintenance_status_table.up.sql
@@ -1,0 +1,8 @@
+
+-- File: 0024_truncate_maintenance_status_table.up.sql
+-- Description: Truncates the maintenance status table since it is no longer used
+
+
+SET search_path TO community, public;
+
+TRUNCATE TABLE community.maintenance_status;

--- a/setup/devscript/test_data.sql
+++ b/setup/devscript/test_data.sql
@@ -43,29 +43,29 @@ VALUES (
 INSERT INTO community.category (name, description, status, color, min_items_limit, max_items_limit, created_by, updated_by, sharable_groups)
 VALUES ('Groceries', 'used for grocery related items', (SELECT id FROM community.statuses s LIMIT 1), '#d20a0a', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
        ('Utilities', 'store boxes and utility related stuffs', (SELECT id FROM community.statuses s LIMIT 1), '#e7d3da', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Entertainment', 'store gaming consoles, tvs, and / or any audio video equipment', (SELECT id FROM community.statuses s LIMIT 1), '#963256', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Transportation', 'used to store bus pass, vehicle keys or any related accesories', (SELECT id FROM community.statuses s LIMIT 1), '#c8aabf', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Clothing', 'used to keep track of all clothings including bags and pants', (SELECT id FROM community.statuses s LIMIT 1), '#d433a7', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Home Maintenance', 'store tools such as belts, screwdrivers, nails etc', (SELECT id FROM community.statuses s LIMIT 1), '#465760', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Education', 'used to store books and study materials', (SELECT id FROM community.statuses s LIMIT 1), '#138ed3', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Miscellaneous', 'used to store stuffs that are totally random', (SELECT id FROM community.statuses s LIMIT 1), '#28b391', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
-
--- ADD MAINTENANCE PLAN STATUS SQL TEST DATA --
-INSERT INTO community.maintenance_status (name, description, created_by, updated_by, sharable_groups)
-VALUES
-    ('Ready for Review', 'The maintenance plan is ready to be reviewed by the appropriate person or team.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('In Review', 'The maintenance plan is currently under review.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('Passed Review', 'The maintenance plan has successfully passed the review process.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('Failed Review', 'The maintenance plan did not pass the review process and requires adjustments.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('Pending Approval', 'The maintenance plan is awaiting final approval before proceeding.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('Approved', 'The maintenance plan has been approved and is ready for execution.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-    ('Rejected', 'The maintenance plan has been rejected and will not proceed.', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
+       ('Entertainment', 'store gaming consoles, tvs, and / or any audio video equipment', (SELECT id FROM community.statuses s LIMIT 1), '#963256', 1, 100, (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
 
 -- ADD MAINTENANCE PLAN SQL TEST DATA --
-INSERT INTO community.maintenance_plan (name, description, maintenance_status, color, min_items_limit, max_items_limit, plan_type, location, created_by, updated_by, sharable_groups)
-VALUES ('Daily maintenance plan', 'used to validate daily items', (SELECT id FROM community.maintenance_status mps LIMIT 1), '#d20a0a', 1, 100, 'annual',  '(-119.170898,  34.196411)', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
-       ('Weekly maintenance plan', 'used for weekely maintenance', (SELECT id FROM community.maintenance_status mps LIMIT 1), '#28b391', 1, 100, 'weekly',  '(-117.182541, 34.055569)', (SELECT id FROM community.profiles p LIMIT 1), (SELECT id FROM community.profiles p LIMIT 1), ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
+INSERT INTO community.maintenance_plan 
+(name, description, status, color, min_items_limit, max_items_limit, plan_type, plan_due, location, created_by, updated_by, sharable_groups)
+VALUES 
+('Daily maintenance plan', 'used to validate daily items', 
+ (SELECT id FROM community.statuses mps LIMIT 1), 
+ '#d20a0a', 1, 100, 'annual', 
+ now() + interval '1 year', 
+ '(-119.170898, 34.196411)', 
+ (SELECT id FROM community.profiles p LIMIT 1), 
+ (SELECT id FROM community.profiles p LIMIT 1), 
+ ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]),
 
+('Weekly maintenance plan', 'used for weekly maintenance', 
+ (SELECT id FROM community.statuses mps LIMIT 1), 
+ '#28b391', 1, 100, 'weekly', 
+ now() + interval '7 days', 
+ '(-117.182541, 34.055569)', 
+ (SELECT id FROM community.profiles p LIMIT 1), 
+ (SELECT id FROM community.profiles p LIMIT 1), 
+ ARRAY [(SELECT id FROM community.profiles p LIMIT 1)::UUID]);
 
 -- ADD INVENTORIES SQL TEST DATA --
 INSERT INTO community.inventory (name, description, price, status, barcode, sku, quantity, bought_at, location,


### PR DESCRIPTION
- updated 0023_update_table_maintenance_plan to support due date
- updated unit test and test_data.sql
- seperate status code for maintenance plan
- updated test_data.sql to support maintenance status
- updated dataLake and added ability to populate fake categories and maintenance plans
- updated unit tests
- truncate maintenance status table
- updated ui to support due date in plans
- updated datalake to support maintenance plans
- updated status list for uniformity between categories, notes and maintenance plans
- updated add plans form fields and constants
- fix lint issues


# Screenshots / Visuals

![image](https://github.com/user-attachments/assets/e170e4c8-fecc-4c0a-85f6-ccce413f5863)
![image](https://github.com/user-attachments/assets/246ce447-c44d-476d-85dc-aeed5b3529dc)


closes #204