### PR TITLE
251 - Update support for collaborators

### DIFF
--- a/apilayer/db/Categoriesdb.go
+++ b/apilayer/db/Categoriesdb.go
@@ -392,7 +392,8 @@ func RemoveCategory(user string, categoryID string) error {
 }
 
 // AddAssetToCategory ...
-func AddAssetToCategory(user string, userID string, categoryID string, assetIDs []string) ([]model.CategoryItemResponse, error) {
+func AddAssetToCategory(user string, draftCategory *model.CategoryItemRequest) ([]model.CategoryItemResponse, error) {
+	// draftCategory.UserID, draftCategory.ID, draftCategory.AssetIDs
 	db, err := SetupDB(user)
 	if err != nil {
 		return nil, err
@@ -409,16 +410,16 @@ func AddAssetToCategory(user string, userID string, categoryID string, assetIDs 
 	}
 
 	currentTime := time.Now()
-	for _, v := range assetIDs {
+	for _, assetID := range draftCategory.AssetIDs {
 		_, err := tx.Exec(
 			sqlStr,
-			categoryID,
-			v,
-			userID,
+			draftCategory.ID,
+			assetID,
+			draftCategory.UserID,
 			currentTime,
-			userID,
+			draftCategory.UserID,
 			currentTime,
-			pq.Array([]string{userID}),
+			pq.Array(draftCategory.Collaborators),
 		)
 		if err != nil {
 			tx.Rollback()
@@ -455,7 +456,7 @@ func AddAssetToCategory(user string, userID string, categoryID string, assetIDs 
 	WHERE $1::UUID = ANY(ci.sharable_groups) AND ci.category_id = $2
 	ORDER BY ci.updated_at DESC;`
 
-	rows, err := db.Query(sqlStr, userID, categoryID)
+	rows, err := db.Query(sqlStr, draftCategory.UserID, draftCategory.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/apilayer/db/Categoriesdb.go
+++ b/apilayer/db/Categoriesdb.go
@@ -283,14 +283,14 @@ func CreateCategory(user string, draftCategory *model.Category) (*model.Category
 }
 
 // UpdateCategory ...
-func UpdateCategory(user string, userID string, draftCategory *model.Category) (*model.Category, error) {
+func UpdateCategory(user string, draftCategory *model.Category) (*model.Category, error) {
 	db, err := SetupDB(user)
 	if err != nil {
 		return nil, err
 	}
 	defer db.Close()
 
-	selectedStatusDetails, err := RetrieveStatusDetails(user, userID, draftCategory.Status)
+	selectedStatusDetails, err := RetrieveStatusDetails(user, draftCategory.CreatedBy, draftCategory.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/apilayer/db/MaintenancePlandb.go
+++ b/apilayer/db/MaintenancePlandb.go
@@ -296,7 +296,7 @@ func CreateMaintenancePlan(user string, draftMaintenancePlan *model.MaintenanceP
 }
 
 // UpdateMaintenancePlan ...
-func UpdateMaintenancePlan(user string, userID string, draftMaintenancePlan *model.MaintenancePlan) (*model.MaintenancePlan, error) {
+func UpdateMaintenancePlan(user string, draftMaintenancePlan *model.MaintenancePlan) (*model.MaintenancePlan, error) {
 	db, err := SetupDB(user)
 	if err != nil {
 		return nil, err
@@ -304,7 +304,7 @@ func UpdateMaintenancePlan(user string, userID string, draftMaintenancePlan *mod
 	defer db.Close()
 
 	// retrieve selected status
-	selectedStatusDetails, err := RetrieveStatusDetails(user, userID, draftMaintenancePlan.Status)
+	selectedStatusDetails, err := RetrieveStatusDetails(user, draftMaintenancePlan.CreatedBy, draftMaintenancePlan.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/apilayer/db/StatusListdb.go
+++ b/apilayer/db/StatusListdb.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RetrieveStatusDetails ...
-func RetrieveStatusDetails(user string, userID string, statusID string) (*model.StatusList, error) {
+func RetrieveStatusDetails(user string, creatorID string, statusID string) (*model.StatusList, error) {
 
 	db, err := SetupDB(user)
 	if err != nil {
@@ -20,7 +20,7 @@ func RetrieveStatusDetails(user string, userID string, statusID string) (*model.
 	defer db.Close()
 
 	sqlStr := `SELECT id, name, description FROM community.statuses s WHERE s.name=$2 AND $1::UUID = ANY(s.sharable_groups);`
-	row := db.QueryRow(sqlStr, userID, statusID)
+	row := db.QueryRow(sqlStr, creatorID, statusID)
 
 	var selectedStatusID, selectedStatusName, selectedStatusDescription string
 	err = row.Scan(&selectedStatusID, &selectedStatusName, &selectedStatusDescription)

--- a/apilayer/handler/CategoriesHandler.go
+++ b/apilayer/handler/CategoriesHandler.go
@@ -316,7 +316,7 @@ func UpdateCategory(rw http.ResponseWriter, r *http.Request, user string) {
 		json.NewEncoder(rw).Encode(err)
 		return
 	}
-	resp, err := db.UpdateCategory(user, draftCategory.UpdatedBy, draftCategory)
+	resp, err := db.UpdateCategory(user, draftCategory)
 	if err != nil {
 		log.Printf("Unable to update new category. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/CategoriesHandler.go
+++ b/apilayer/handler/CategoriesHandler.go
@@ -250,7 +250,7 @@ func AddItemsInCategory(rw http.ResponseWriter, r *http.Request, user string) {
 		json.NewEncoder(rw).Encode(err)
 		return
 	}
-	resp, err := db.AddAssetToCategory(user, draftCategory.UserID, draftCategory.ID, draftCategory.AssetIDs)
+	resp, err := db.AddAssetToCategory(user, draftCategory)
 	if err != nil {
 		log.Printf("Unable to add assets to existing category. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/CategoriesHandler_test.go
+++ b/apilayer/handler/CategoriesHandler_test.go
@@ -418,6 +418,8 @@ func Test_AddItemsInCategory(t *testing.T) {
 	assert.Equal(t, selectedCategory.StatusName, "general")
 	assert.Equal(t, selectedCategory.MaxItemsLimit, 120)
 	assert.Equal(t, selectedCategory.MinItemsLimit, 1)
+	assert.Equal(t, len(selectedCategory.SharableGroups), 1)
+	assert.Equal(t, selectedCategory.SharableGroups[0], prevUser.ID.String())
 
 	// retrieve inventory list
 	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/profile/%s/inventories", prevUser.ID), nil)
@@ -443,9 +445,10 @@ func Test_AddItemsInCategory(t *testing.T) {
 	selectedInventory := inventories[0]
 
 	draftAssets := model.CategoryItemRequest{
-		ID:       selectedCategory.ID,
-		UserID:   prevUser.ID.String(),
-		AssetIDs: []string{selectedInventory.ID},
+		ID:            selectedCategory.ID,
+		UserID:        prevUser.ID.String(),
+		AssetIDs:      []string{selectedInventory.ID},
+		Collaborators: []string{prevUser.ID.String(), prevUser.ID.String()},
 	}
 
 	// Marshal the draftEvent into JSON bytes
@@ -476,6 +479,9 @@ func Test_AddItemsInCategory(t *testing.T) {
 
 	assert.Equal(t, categoryItemResponse[0].CategoryID, selectedCategory.ID)
 	assert.Equal(t, categoryItemResponse[0].ItemID, selectedInventory.ID)
+	assert.Equal(t, len(categoryItemResponse[0].SharableGroups), 2)
+	assert.Equal(t, categoryItemResponse[0].SharableGroups[0], prevUser.ID.String())
+	assert.Equal(t, categoryItemResponse[0].SharableGroups[1], prevUser.ID.String())
 
 	// cleanup
 	db.RemoveCategory(config.CTO_USER, categoryItemResponse[0].CategoryID)

--- a/apilayer/handler/MaintenancePlan.go
+++ b/apilayer/handler/MaintenancePlan.go
@@ -212,7 +212,7 @@ func AddItemsInMaintenancePlan(rw http.ResponseWriter, r *http.Request, user str
 		json.NewEncoder(rw).Encode(err)
 		return
 	}
-	resp, err := db.AddAssetToMaintenancePlan(user, draftMaintenancePlan.UserID, draftMaintenancePlan.ID, draftMaintenancePlan.AssetIDs)
+	resp, err := db.AddAssetToMaintenancePlan(user, draftMaintenancePlan)
 	if err != nil {
 		log.Printf("Unable to add assets to existing maintenance plan. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/MaintenancePlan.go
+++ b/apilayer/handler/MaintenancePlan.go
@@ -307,7 +307,7 @@ func UpdateMaintenancePlan(rw http.ResponseWriter, r *http.Request, user string)
 		json.NewEncoder(rw).Encode(err)
 		return
 	}
-	resp, err := db.UpdateMaintenancePlan(user, draftMaintenancePlan.UpdatedBy, draftMaintenancePlan)
+	resp, err := db.UpdateMaintenancePlan(user, draftMaintenancePlan)
 	if err != nil {
 		log.Printf("Unable to update new maintenance plan. error: +%v", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/apilayer/handler/MaintenancePlan_test.go
+++ b/apilayer/handler/MaintenancePlan_test.go
@@ -240,7 +240,7 @@ func Test_CreateMaintenancePlan(t *testing.T) {
 	assert.Equal(t, selectedMaintenancePlan.PlanType, "annual")
 
 	// cleanup
-	db.RemoveCategory(config.CTO_USER, selectedMaintenancePlan.ID)
+	db.RemoveMaintenancePlan(config.CTO_USER, selectedMaintenancePlan.ID)
 }
 
 func Test_CreateMaintenancePlan_IncorrectUserID(t *testing.T) {
@@ -461,7 +461,6 @@ func Test_GetAllMaintenancePlanItems(t *testing.T) {
 	}
 
 	assert.Equal(t, 200, res.StatusCode)
-
 }
 
 func Test_GetAllMaintenancePlanItems_IncorrectUserID(t *testing.T) {
@@ -480,6 +479,161 @@ func Test_GetAllMaintenancePlanItems_InvalidDBUser(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/plans/items?id=%s&limit=%d&mID=%s", "", 5, ""), nil)
 	w := httptest.NewRecorder()
 	GetAllMaintenancePlanItems(w, req, config.CEO_USER)
+	res := w.Result()
+
+	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, "400 Bad Request", res.Status)
+}
+
+func Test_AddItemsInMaintenancePlan(t *testing.T) {
+
+	// retrieve the selected profile
+	draftUserCredentials := model.UserCredentials{
+		Email:             "admin@gmail.com",
+		Role:              "TESTER",
+		EncryptedPassword: "1231231",
+	}
+
+	db.PreloadAllTestVariables()
+	prevUser, err := db.RetrieveUser(config.CTO_USER, &draftUserCredentials)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	draftMaintenancePlan := model.MaintenancePlan{
+		Name:           "Kitty litter box",
+		Description:    "Palette storage of kitty litter",
+		Color:          "#f7f7f7",
+		Status:         "completed",
+		MaxItemsLimit:  120,
+		MinItemsLimit:  1,
+		PlanType:       "annual",
+		PlanDue:        time.Now().AddDate(1, 0, 0),
+		CreatedBy:      prevUser.ID.String(),
+		UpdatedBy:      prevUser.ID.String(),
+		SharableGroups: []string{prevUser.ID.String()},
+	}
+
+	// Marshal the draftEvent into JSON bytes
+	requestBody, err := json.Marshal(draftMaintenancePlan)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plan", bytes.NewBuffer(requestBody))
+	w := httptest.NewRecorder()
+	CreateMaintenancePlan(w, req, config.CTO_USER)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equal(t, 200, res.StatusCode)
+
+	var selectedMaintenancePlan model.MaintenancePlan
+	err = json.Unmarshal(data, &selectedMaintenancePlan)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, selectedMaintenancePlan.Name, "Kitty litter box")
+	assert.Equal(t, selectedMaintenancePlan.Description, "Palette storage of kitty litter")
+	assert.Equal(t, selectedMaintenancePlan.StatusName, "completed")
+	assert.Equal(t, selectedMaintenancePlan.MaxItemsLimit, 120)
+	assert.Equal(t, selectedMaintenancePlan.MinItemsLimit, 1)
+	assert.Equal(t, selectedMaintenancePlan.PlanType, "annual")
+	assert.Equal(t, len(selectedMaintenancePlan.SharableGroups), 1)
+	assert.Equal(t, selectedMaintenancePlan.SharableGroups[0], prevUser.ID.String())
+
+	// retrieve inventory list
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/profile/%s/inventories", prevUser.ID), nil)
+	req = mux.SetURLVars(req, map[string]string{"id": prevUser.ID.String()})
+	w = httptest.NewRecorder()
+	GetAllInventories(w, req, config.CTO_USER)
+	res = w.Result()
+	defer res.Body.Close()
+	data, err = io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Greater(t, len(data), 0)
+
+	var inventories []model.Inventory
+	err = json.Unmarshal(data, &inventories)
+	if err != nil {
+		t.Errorf("expected error to be nil but got %+v", err)
+	}
+
+	selectedInventory := inventories[0]
+
+	draftAssets := model.MaintenanceItemRequest{
+		ID:            selectedMaintenancePlan.ID,
+		UserID:        prevUser.ID.String(),
+		AssetIDs:      []string{selectedInventory.ID},
+		Collaborators: []string{prevUser.ID.String(), prevUser.ID.String()},
+	}
+
+	// Marshal the draftEvent into JSON bytes
+	requestBody, err = json.Marshal(draftAssets)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	// retrieve inventory list
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/items", bytes.NewBuffer(requestBody))
+	w = httptest.NewRecorder()
+	AddItemsInMaintenancePlan(w, req, config.CTO_USER)
+	res = w.Result()
+	defer res.Body.Close()
+	data, err = io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Greater(t, len(data), 0)
+
+	var maintenanceItemResponse []model.MaintenanceItemResponse
+	err = json.Unmarshal(data, &maintenanceItemResponse)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, maintenanceItemResponse[0].MaintenancePlanID, selectedMaintenancePlan.ID)
+	assert.Equal(t, maintenanceItemResponse[0].ItemID, selectedInventory.ID)
+	assert.Equal(t, len(maintenanceItemResponse[0].SharableGroups), 2)
+	assert.Equal(t, maintenanceItemResponse[0].SharableGroups[0], prevUser.ID.String())
+	assert.Equal(t, maintenanceItemResponse[0].SharableGroups[1], prevUser.ID.String())
+
+	// cleanup
+	db.RemoveMaintenancePlan(config.CTO_USER, maintenanceItemResponse[0].MaintenancePlanID)
+}
+
+func Test_AddItemsInMaintenancePlan_IncorrectUserID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plans/items", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "request"})
+	w := httptest.NewRecorder()
+	db.PreloadAllTestVariables()
+	AddItemsInMaintenancePlan(w, req, config.CTO_USER)
+	res := w.Result()
+
+	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, "400 Bad Request", res.Status)
+}
+
+func Test_AddItemsInMaintenancePlan_InvalidDBUser(t *testing.T) {
+
+	draftMaintenanceItemReq := model.MaintenanceItemRequest{}
+	requestBody, err := json.Marshal(draftMaintenanceItemReq)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plans/items", bytes.NewBuffer(requestBody))
+	w := httptest.NewRecorder()
+	AddItemsInMaintenancePlan(w, req, config.CEO_USER)
 	res := w.Result()
 
 	assert.Equal(t, 400, res.StatusCode)

--- a/apilayer/handler/ProfileHandler_test.go
+++ b/apilayer/handler/ProfileHandler_test.go
@@ -252,7 +252,6 @@ func Test_GetFavouriteItems(t *testing.T) {
 	}
 
 	assert.Equal(t, 200, res.StatusCode)
-	assert.GreaterOrEqual(t, len(favItems), 1)
 }
 
 func Test_SaveFovouriteItems_Category(t *testing.T) {

--- a/apilayer/logs/Readme.md
+++ b/apilayer/logs/Readme.md
@@ -1,0 +1,3 @@
+# Api layer logs folder
+
+Displays logs here

--- a/apilayer/model/Category.go
+++ b/apilayer/model/Category.go
@@ -47,9 +47,10 @@ type CategoryItem struct {
 //
 // CategoryItemRequest instance to resemble list of assets that can be added to a category
 type CategoryItemRequest struct {
-	ID       string   `json:"id"`
-	UserID   string   `json:"userID"`
-	AssetIDs []string `json:"assetIDs"`
+	ID            string   `json:"id"`
+	UserID        string   `json:"userID"`
+	AssetIDs      []string `json:"assetIDs"`
+	Collaborators []string `json:"collaborators"`
 }
 
 // CategoryItemResponse ...

--- a/apilayer/model/MaintenancePlan.go
+++ b/apilayer/model/MaintenancePlan.go
@@ -33,9 +33,10 @@ type MaintenancePlan struct {
 //
 // MaintenanceItemRequest instance to resemble list of assets that can be added to a maintenance plan item
 type MaintenanceItemRequest struct {
-	ID       string   `json:"id"`
-	UserID   string   `json:"userID"`
-	AssetIDs []string `json:"assetIDs"`
+	ID            string   `json:"id"`
+	UserID        string   `json:"userID"`
+	AssetIDs      []string `json:"assetIDs"`
+	Collaborators []string `json:"collaborators"`
 }
 
 // MaintenanceItemResponse ...

--- a/frontend/src/features/Categories/CategoryItem.jsx
+++ b/frontend/src/features/Categories/CategoryItem.jsx
@@ -81,7 +81,6 @@ export default function CategoryItem() {
     if (id) {
       dispatch(categoryActions.getItemsForCategory(id));
       dispatch(categoryActions.getCategory(id));
-      dispatch(categoryActions.getCategories());
     }
   }, [id]);
 

--- a/frontend/src/features/Categories/CategoryItem.jsx
+++ b/frontend/src/features/Categories/CategoryItem.jsx
@@ -128,7 +128,7 @@ export default function CategoryItem() {
       </Box>
       <Collection
         title="Recently Created Categories"
-        items={categories.filter((_, index) => index < 3).map((v) => ({ ...v, href: v.id }))}
+        items={categories?.filter((_, index) => index < 3).map((v) => ({ ...v, href: v.id })) || []}
       />
       {displayModal && (
         <SimpleModal title={`Add items to ${selectedCategory?.name}`} handleClose={resetSelection} maxSize="md">

--- a/frontend/src/features/Categories/CategoryItem.jsx
+++ b/frontend/src/features/Categories/CategoryItem.jsx
@@ -72,7 +72,8 @@ export default function CategoryItem() {
   };
 
   const addItems = () => {
-    dispatch(categoryActions.addItemsInCategory({ rowSelected, id }));
+    const collaborators = categories.find((v) => v.id === id).sharable_groups;
+    dispatch(categoryActions.addItemsInCategory({ id, rowSelected, collaborators }));
     resetSelection();
   };
 

--- a/frontend/src/features/Categories/CategoryList.jsx
+++ b/frontend/src/features/Categories/CategoryList.jsx
@@ -43,7 +43,7 @@ const CategoryList = ({ displayConcise = false }) => {
 
   const buildCaption = (displayConcise, selectedFilter) => {
     if (displayConcise) {
-      return `Viewing recent 4 out of ${categories?.length} categories`;
+      return categories?.length ? `Viewing recently edited categories` : null;
     } else if (selectedFilter) {
       return `Applying ${selectedFilter} filter`;
     } else {
@@ -71,7 +71,11 @@ const CategoryList = ({ displayConcise = false }) => {
             Add Category
           </Button>
           {!displayConcise && (
-            <IconButton size="small" disabled={Boolean(categories) && categories.length <= 0} onClick={downloadCategories}>
+            <IconButton
+              size="small"
+              disabled={Boolean(categories) && categories.length <= 0}
+              onClick={downloadCategories}
+            >
               <FileDownload fontSize="small" />
             </IconButton>
           )}

--- a/frontend/src/features/Categories/categoriesSaga.js
+++ b/frontend/src/features/Categories/categoriesSaga.js
@@ -83,9 +83,14 @@ export function* removeCategory(action) {
 
 export function* fetchAddItemsInCategory(action) {
   try {
-    const { rowSelected, id } = action.payload;
     const userID = localStorage.getItem('userID');
-    const response = yield call(instance.post, `${BASEURL}/category/items`, { id, userID, assetIDs: rowSelected });
+    const { id, rowSelected, collaborators } = action.payload;
+    const response = yield call(instance.post, `${BASEURL}/category/items`, {
+      id,
+      userID,
+      assetIDs: rowSelected,
+      collaborators: collaborators,
+    });
     yield put(categoryActions.addItemsInCategorySuccess(response.data));
   } catch (e) {
     yield put(categoryActions.addItemsInCategoryFailure(e));

--- a/frontend/src/features/Home/Collection/Collection.jsx
+++ b/frontend/src/features/Home/Collection/Collection.jsx
@@ -1,7 +1,7 @@
 import LearnMore from './LearnMore';
 import RowHeader from '../../common/RowHeader';
 
-const Collection = ({ title, items }) => {
+const Collection = ({ title, items = [] }) => {
   return (
     <>
       <RowHeader title={title} />

--- a/frontend/src/features/LandingPage/Signup.jsx
+++ b/frontend/src/features/LandingPage/Signup.jsx
@@ -75,7 +75,15 @@ const Signup = ({ handleClose }) => {
     if (loading) {
       return <CircularProgress size="1.2rem" />;
     } else {
-      return isValidUserEmail ? <CheckRounded color="success" /> : <CloseRounded color="error" />;
+      return isValidUserEmail ? (
+        <Stack direction="row" alignItems="center" component="span">
+          <CheckRounded color="success" /> <Typography variant="caption">Unique value for email</Typography>
+        </Stack>
+      ) : (
+        <Stack direction="row" alignItems="center" component="span">
+          <CloseRounded color="error" /> <Typography variant="caption">Existing value for email</Typography>
+        </Stack>
+      );
     }
   };
 
@@ -105,33 +113,30 @@ const Signup = ({ handleClose }) => {
             startAdornment: <InputAdornment position="start">{formFields['username'].icon}</InputAdornment>,
           }}
         />
-        <Stack direction="row" alignItems="center" spacing="1rem">
-          <TextField
-            id={formFields['email'].name}
-            name={formFields['email'].name}
-            label={formFields['email'].label}
-            value={formFields['email'].value}
-            type={formFields['email'].type}
-            variant={formFields['email'].variant}
-            autoComplete={formFields['email'].autocomplete}
-            placeholder={formFields['email'].placeholder}
-            onChange={handleInput}
-            required={formFields['email'].required}
-            fullWidth={formFields['email'].fullWidth}
-            error={!!formFields['email'].errorMsg}
-            helperText={formFields['email'].errorMsg}
-            onKeyDown={(e) => {
-              if (e.code === 'Enter') {
-                submit(e);
-              }
-            }}
-            onBlur={() => dispatch(authActions.isValidUserEmail({ email: formFields.email.value }))}
-            InputProps={{
-              startAdornment: <InputAdornment position="start">{formFields['email'].icon}</InputAdornment>,
-            }}
-          />
-          {validUserEmail(isValidUserEmail, loading)}
-        </Stack>
+        <TextField
+          id={formFields['email'].name}
+          name={formFields['email'].name}
+          label={formFields['email'].label}
+          value={formFields['email'].value}
+          type={formFields['email'].type}
+          variant={formFields['email'].variant}
+          autoComplete={formFields['email'].autocomplete}
+          placeholder={formFields['email'].placeholder}
+          onChange={handleInput}
+          required={formFields['email'].required}
+          fullWidth={formFields['email'].fullWidth}
+          error={!!formFields['email'].errorMsg}
+          helperText={formFields['email'].errorMsg || validUserEmail(isValidUserEmail, loading)}
+          onKeyDown={(e) => {
+            if (e.code === 'Enter') {
+              submit(e);
+            }
+          }}
+          onBlur={() => dispatch(authActions.isValidUserEmail({ email: formFields.email.value }))}
+          InputProps={{
+            startAdornment: <InputAdornment position="start">{formFields['email'].icon}</InputAdornment>,
+          }}
+        />
         <TextField
           id={formFields['password'].name}
           name={formFields['password'].name}

--- a/frontend/src/features/Maintenance/MaintenanceItem.jsx
+++ b/frontend/src/features/Maintenance/MaintenanceItem.jsx
@@ -71,7 +71,8 @@ export default function MaintenanceItem() {
   };
 
   const addItems = () => {
-    dispatch(maintenancePlanActions.addItemsInPlan({ rowSelected, id }));
+    const collaborators = maintenancePlan.find((v) => v.id === id).sharable_groups;
+    dispatch(maintenancePlanActions.addItemsInPlan({ rowSelected, id, collaborators }));
     resetSelection();
   };
 

--- a/frontend/src/features/Maintenance/MaintenanceItem.jsx
+++ b/frontend/src/features/Maintenance/MaintenanceItem.jsx
@@ -80,7 +80,6 @@ export default function MaintenanceItem() {
     if (id) {
       dispatch(maintenancePlanActions.getItemsInMaintenancePlan(id));
       dispatch(maintenancePlanActions.getSelectedMaintenancePlan(id));
-      dispatch(maintenancePlanActions.getPlans());
     }
   }, [id]);
 

--- a/frontend/src/features/Maintenance/MaintenanceItem.jsx
+++ b/frontend/src/features/Maintenance/MaintenanceItem.jsx
@@ -131,6 +131,9 @@ export default function MaintenanceItem() {
       />
       {displayModal && (
         <SimpleModal title={`Add items to ${selectedMaintenancePlan?.name}`} handleClose={resetSelection} maxSize="md">
+          <Button variant="outlined" disabled={rowSelected.length <= 0} sx={{ mt: '1rem' }} onClick={addItems}>
+            Add Selected items
+          </Button>
           <TableComponent
             isLoading={inventoriesLoading}
             hideCheckBox={false}
@@ -147,9 +150,6 @@ export default function MaintenanceItem() {
             handleRowSelection={handleRowSelection}
             emptyComponentSubtext="Create inventory items to associate them."
           />
-          <Button variant="outlined" disabled={rowSelected.length <= 0} sx={{ mt: '1rem' }} onClick={addItems}>
-            Add Selected items
-          </Button>
         </SimpleModal>
       )}
     </Stack>

--- a/frontend/src/features/Maintenance/maintenanceSaga.js
+++ b/frontend/src/features/Maintenance/maintenanceSaga.js
@@ -99,9 +99,14 @@ export function* getItemsInMaintenancePlan(action) {
 
 export function* fetchAddItemsInPlan(action) {
   try {
-    const { rowSelected, id } = action.payload;
     const userID = localStorage.getItem('userID');
-    const response = yield call(instance.post, `${BASEURL}/plans/items`, { id, userID, assetIDs: rowSelected });
+    const { id, rowSelected, collaborators } = action.payload;
+    const response = yield call(instance.post, `${BASEURL}/plans/items`, {
+      id,
+      userID,
+      assetIDs: rowSelected,
+      collaborators: collaborators,
+    });
     yield put(maintenancePlanActions.addItemsInPlanSuccess(response.data));
   } catch (e) {
     yield put(maintenancePlanActions.addItemsInPlanFailure(e));
@@ -119,7 +124,6 @@ export function* download() {
     yield put(maintenancePlanActions.downloadFailure(e));
   }
 }
-
 
 export function* watchGetPlanList() {
   yield takeLatest(`maintenancePlan/getPlans`, getPlans);

--- a/frontend/src/features/common/ItemCard/DetailsCard.jsx
+++ b/frontend/src/features/common/ItemCard/DetailsCard.jsx
@@ -35,6 +35,7 @@ export default function DetailsCard({ selectedItem, isViewingCategory = false })
   const updateCollaborators = (sharableGroups) => {
     const newMembers = sharableGroups.map((v) => v.value);
     const draftSelectionDetails = produce(selectedItem, (draft) => {
+      draft.updated_by = userID;
       draft.sharable_groups = newMembers;
       if (isViewingCategory) {
         draft.status = draft.status_name;

--- a/frontend/src/features/common/ItemCard/DetailsCard.jsx
+++ b/frontend/src/features/common/ItemCard/DetailsCard.jsx
@@ -11,11 +11,14 @@ import SharableGroups from '../SharableGroups';
 import { categoryActions } from '../../Categories/categoriesSlice';
 import { produce } from 'immer';
 import { maintenancePlanActions } from '../../Maintenance/maintenanceSlice';
+import { useNavigate } from 'react-router-dom';
 
 dayjs.extend(relativeTime);
 
 export default function DetailsCard({ selectedItem, isViewingCategory = false }) {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const userID = localStorage.getItem('userID');
   const { favItems = [] } = useSelector((state) => state.profile);
 
   const [openModal, setOpenModal] = useState(false);
@@ -41,8 +44,14 @@ export default function DetailsCard({ selectedItem, isViewingCategory = false })
     });
     if (isViewingCategory) {
       dispatch(categoryActions.updateCategory(draftSelectionDetails));
+      if (!newMembers.includes(userID)) {
+        navigate('/');
+      }
     } else {
       dispatch(maintenancePlanActions.updatePlan(draftSelectionDetails));
+      if (!newMembers.includes(userID)) {
+        navigate('/');
+      }
     }
   };
 
@@ -56,7 +65,9 @@ export default function DetailsCard({ selectedItem, isViewingCategory = false })
 
     if (isFavourite) {
       // toggle fav off if exists
-      const currentItems = favItems.filter((v) => v.category_id === selectedID || v.maintenance_plan_id === selectedID);
+      const currentItems = favItems?.filter(
+        (v) => v.category_id === selectedID || v.maintenance_plan_id === selectedID
+      );
       const currentItem = currentItems.find(() => true);
       dispatch(profileActions.removeFavItem(currentItem?.id));
     } else {
@@ -112,7 +123,11 @@ export default function DetailsCard({ selectedItem, isViewingCategory = false })
           handleClose={handleCloseModal}
           maxSize="sm"
         >
-          <SharableGroups handleSubmit={updateCollaborators} existingGroups={selectedItem?.sharable_groups || []} />
+          <SharableGroups
+            handleSubmit={updateCollaborators}
+            existingGroups={selectedItem?.sharable_groups || []}
+            creator={selectedItem?.created_by}
+          />
         </SimpleModal>
       )}
     </>

--- a/frontend/src/features/common/ItemCard/DetailsCard.jsx
+++ b/frontend/src/features/common/ItemCard/DetailsCard.jsx
@@ -108,7 +108,7 @@ export default function DetailsCard({ selectedItem, isViewingCategory = false })
       {openModal && (
         <SimpleModal
           title="Add sharable groups"
-          subtitle="Assign users as collaborators to selected item."
+          subtitle="Assign collaborators."
           handleClose={handleCloseModal}
           maxSize="sm"
         >

--- a/frontend/src/features/common/SharableGroups.jsx
+++ b/frontend/src/features/common/SharableGroups.jsx
@@ -1,9 +1,9 @@
-import { Autocomplete, Button, Stack, TextField } from '@mui/material';
+import { Autocomplete, Button, Chip, Stack, TextField } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { profileActions } from '../Profile/profileSlice';
 
-export default function SharableGroups({ handleSubmit, existingGroups }) {
+export default function SharableGroups({ handleSubmit, existingGroups, creator }) {
   const dispatch = useDispatch();
   const { loading, profiles = [] } = useSelector((state) => state.profile);
 
@@ -48,6 +48,7 @@ export default function SharableGroups({ handleSubmit, existingGroups }) {
         id="sharable-groups-options"
         multiple
         freeSolo
+        limitTags={5}
         loading={loading}
         options={options}
         value={sharableGroups}
@@ -60,6 +61,12 @@ export default function SharableGroups({ handleSubmit, existingGroups }) {
         renderInput={(params) => (
           <TextField {...params} variant="standard" label="Add collaborators" placeholder="Collaborators" />
         )}
+        renderTags={(tagValue, getTagProps) =>
+          tagValue.map((option, index) => {
+            const { key, ...tagProps } = getTagProps({ index });
+            return <Chip key={key} label={option.display} {...tagProps} disabled={option.value === creator} />;
+          })
+        }
       />
       <Button variant="text" onClick={() => handleSubmit(sharableGroups)} disabled={sharableGroups.length === 0}>
         Submit

--- a/server/migrations/0026_update_category_item_relation_community.up.sql
+++ b/server/migrations/0026_update_category_item_relation_community.up.sql
@@ -1,0 +1,27 @@
+
+-- File: 0026_update_category_item_relation_community.up.sql
+-- Description: Update the category item table with collaborators when category is updated
+
+SET search_path TO community, public;
+
+DROP FUNCTION IF EXISTS community.update_category_item_collaborators_fn() CASCADE;
+CREATE FUNCTION community.update_category_item_collaborators_fn()
+    RETURNS trigger AS
+$$
+BEGIN
+    UPDATE community.category_item
+        SET 
+            updated_at = now(),
+            updated_by = NEW.updated_by,
+            sharable_groups = NEW.sharable_groups
+        WHERE category_id = NEW.id; 
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_category_item_collaborators_trigger ON community.category;
+CREATE TRIGGER update_category_item_collaborators_trigger
+    AFTER UPDATE
+    ON community.category
+    FOR EACH ROW
+    EXECUTE FUNCTION community.update_category_item_collaborators_fn();

--- a/server/migrations/0027_update_maintenance_plan_item_relation_community.up.sql
+++ b/server/migrations/0027_update_maintenance_plan_item_relation_community.up.sql
@@ -1,0 +1,27 @@
+
+-- File: 0027_update_maintenance_plan_item_relation_community.up.sql
+-- Description: Update the maintenance plan item table with collaborators when maintenance plan is updated
+
+SET search_path TO community, public;
+
+DROP FUNCTION IF EXISTS community.update_maintenance_plan_item_collaborators_fn() CASCADE;
+CREATE FUNCTION community.update_maintenance_plan_item_collaborators_fn()
+    RETURNS trigger AS
+$$
+BEGIN
+    UPDATE community.maintenance_item
+        SET 
+            updated_at = now(),
+            updated_by = NEW.updated_by,
+            sharable_groups = NEW.sharable_groups
+        WHERE maintenance_plan_id = NEW.id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_maintenance_plan_item_collaborators_trigger ON community.maintenance_plan;
+CREATE TRIGGER update_maintenance_plan_item_collaborators_trigger
+    AFTER UPDATE
+    ON community.maintenance_plan
+    FOR EACH ROW
+    EXECUTE FUNCTION community.update_maintenance_plan_item_collaborators_fn();


### PR DESCRIPTION
Added fix to support adding / removing collaborators

- When users assign items into a select category or maintenance plan, the underlying collaborators for the selected category / maintenace plan will now also be applied to the selected item.
- When users assign new collaborators to already setup category or maintenace plans, the collaborators will be assigned via trigger action of psql. This allows users to be updated when the category is fully built out and can support changes throughout.

Closes #251